### PR TITLE
Added touchpad, logo and front regions

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-This program can change the colors on your MSI steelseries keyboard. The keyboards have 3 regions that can have different colors for each one.
+This program can change the colors on your MSI steelseries keyboard. Depending on the model, the keyboards have 3 or 7 regions that can have different colors for each one.
 
 Prerequisites (tested on Ubuntu 14.04 only):
 
@@ -22,11 +22,12 @@ Options:
   -h, --help     Displays this help.
   -v, --version  Displays version information.
   -m, --mode <mode>      set color <mode>: normal, gaming, breathe, demo, wave
-  -c, --color <color>    set a <color> using the format: region,red,green,blue
-                         with rgb values between 0 and 255
-  -p, --preset <preset>  set a color <preset> using the format:
-                         region,color,intensity (only valid for
-                         left/middle/right regions)
+  -r, --rgb <rgb>      set an <rgb> color using the format:
+                       region,red,green,blue with rgb values between 0 and 255
+  -c, --color <color>  set a <color> preset using the format:
+                       region,color,intensity (only valid for left/middle/right
+                       regions). When using this option, a mode must be
+                       specified with -m
 
 Available regions:
 
@@ -59,8 +60,7 @@ light
 
 Example:
 
-./msi-keyboard -m normal -p left,red,high -p middle,purple,high -p right,sky,high -c touchpad,255,0,0
-
+./msi-keyboard -m normal -c left,red,high -c middle,purple,high -c right,sky,high -r touchpad,255,0,0 -r logo,255,255,255
 
 Licensing:
 
@@ -72,4 +72,4 @@ Copyright (c) 2013 | Steve Lacy slacy.me | Fractal wearefractal.com contact@wear
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+$The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

--- a/README
+++ b/README
@@ -21,16 +21,24 @@ Keyboard color changer for MSI steelseries keyboards
 Options:
   -h, --help     Displays this help.
   -v, --version  Displays version information.
-  -m, --mode     set color mode: normal, gaming, breathe, demo, wave
-  -c, --color    set a color using the format: region,color,intensity
+  -m, --mode <mode>      set color <mode>: normal, gaming, breathe, demo, wave
+  -c, --color <color>    set a <color> using the format: region,red,green,blue
+                         with rgb values between 0 and 255
+  -p, --preset <preset>  set a color <preset> using the format:
+                         region,color,intensity (only valid for
+                         left/middle/right regions)
 
 Available regions:
 
 left
 middle
 right
+logo
+front-left
+front-right
+touchpad
 
-Available colors:
+Available color presets (only for left/middle/right regions):
 
 off
 red
@@ -42,7 +50,7 @@ blue
 purple
 white
 
-Available intensities:
+Available preset intensities (only for left/middle/right regions):
 
 high
 medium
@@ -51,7 +59,7 @@ light
 
 Example:
 
-./msi-keyboard -m normal -c left,red,high -c middle,purple,high -c right,sky,high
+./msi-keyboard -m normal -p left,red,high -p middle,purple,high -p right,sky,high -c touchpad,255,0,0
 
 
 Licensing:

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -51,7 +51,7 @@ void Keyboard::setMode(Mode mode) {
   hid_send_feature_report(m_dev, buf, BUFSIZE);
 }
 
-void Keyboard::setColor(Region region, Color color, Intensity intensity) {
+void Keyboard::setColorPreset(Region region, Color color, Intensity intensity) {
   if(!m_dev)
     return;
 
@@ -64,6 +64,24 @@ void Keyboard::setColor(Region region, Color color, Intensity intensity) {
   buf[4] = static_cast<unsigned int>(color);
   buf[5] = static_cast<unsigned int>(intensity);
   buf[6] = 0;
+  buf[7] = 236;
+
+  hid_send_feature_report(m_dev, buf, BUFSIZE);
+}
+
+void Keyboard::setColor(Region region, char* rgb) {
+  if(!m_dev)
+    return;
+
+  unsigned char buf[BUFSIZE] = {0};
+
+  buf[0] = 1;
+  buf[1] = 2;
+  buf[2] = 64;
+  buf[3] = static_cast<unsigned int>(region);
+  buf[4] = rgb[0];
+  buf[5] = rgb[1];
+  buf[6] = rgb[2];
   buf[7] = 236;
 
   hid_send_feature_report(m_dev, buf, BUFSIZE);

--- a/keyboard.h
+++ b/keyboard.h
@@ -22,9 +22,17 @@ enum Mode {
 };
 
 enum Region {
+  //Only the first three can change mode
   REGION_LEFT = 1,
   REGION_MIDDLE = 2,
-  REGION_RIGHT = 3
+  REGION_RIGHT = 3,
+  //SteelSeries Logo
+  LOGO = 4,
+  //Front lights
+  FRL_LEFT = 5,
+  //Touchpad
+  FRL_RIGHT = 6,
+  TOUCHPAD = 7
 };
 
 enum Color {
@@ -53,7 +61,8 @@ public:
   Keyboard();
   ~Keyboard();
   void setMode(Mode mode);
-  void setColor(Region region, Color color, Intensity intensity);
+  void setColorPreset(Region region, Color color, Intensity intensity);
+  void setColor(Region region, char *rgb);
 
 private:
   hid_device *m_dev;

--- a/main.cpp
+++ b/main.cpp
@@ -20,8 +20,8 @@ enum CommandLineParseResult
   CommandLineHelpRequested
 };
 
-struct ColorOption {
-  ColorOption() :
+struct ColorPresetOption {
+  ColorPresetOption() :
   region(REGION_LEFT)
   ,color(COLOR_RED)
   ,intensity(INTENSITY_HIGH)
@@ -32,18 +32,32 @@ struct ColorOption {
   Intensity intensity;
 };
 
+struct ColorOption {
+  ColorOption() :
+  region(TOUCHPAD)
+  ,rgb{0,0,0}
+  {}
+
+  Region region;
+  char rgb[3];
+};
+
+
 struct KeyboardOptions {
   KeyboardOptions() :
   modeOption(MODE_NORMAL)
   ,colorOptions()
   ,modeSet(false)
   ,colorSet(false)
+  ,presetSet(false)
   {}
 
   Mode modeOption;
+  QList<ColorPresetOption*> presetOptions;
   QList<ColorOption*> colorOptions;
   bool modeSet;
   bool colorSet;
+  bool presetSet;
 
   void setMode(QString mode) {
     if(mode == "normal") { modeOption = MODE_NORMAL; }
@@ -55,7 +69,7 @@ struct KeyboardOptions {
     modeSet = true;
   }
 
-  void setColor(QString colorString) {
+  void setColorPreset(QString colorString) {
     QStringList fields = colorString.split(',');
 
     if(fields.count() != 3) {
@@ -68,27 +82,67 @@ struct KeyboardOptions {
     QString color = fields.at(1);
     QString intensity = fields.at(2);
 
+    ColorPresetOption *presetOption = new ColorPresetOption;
+
+    if(region == "left") presetOption->region = REGION_LEFT;
+    else if(region == "middle") presetOption->region = REGION_MIDDLE;
+    else if(region == "right") presetOption->region = REGION_RIGHT;
+    else{
+        std::cerr << "invalid region selection" << std::endl;
+        qApp->quit();
+        return;
+    }
+
+    if(color == "off") presetOption->color = COLOR_OFF;
+    if(color == "red") presetOption->color = COLOR_RED;
+    if(color == "orange") presetOption->color = COLOR_ORANGE;
+    if(color == "yellow") presetOption->color = COLOR_YELLOW;
+    if(color == "green") presetOption->color = COLOR_GREEN;
+    if(color == "sky") presetOption->color = COLOR_SKY;
+    if(color == "blue") presetOption->color = COLOR_BLUE;
+    if(color == "purple") presetOption->color = COLOR_PURPLE;
+    if(color == "white") presetOption->color = COLOR_WHITE;
+
+    if(intensity == "high") presetOption->intensity = INTENSITY_HIGH;
+    if(intensity == "medium") presetOption->intensity = INTENSITY_MEDIUM;
+    if(intensity == "low") presetOption->intensity = INTENSITY_LOW;
+    if(intensity == "light") presetOption->intensity = INTENSITY_LIGHT;
+
+    presetSet = true;
+
+    presetOptions.append(presetOption);
+  }
+
+  void setColor(QString colorString) {
+    QStringList fields = colorString.split(',');
+
+    if(fields.count() != 4) {
+      std::cerr << "invalid color selection" << std::endl;
+      qApp->quit();
+      return;
+    }
+
+    QString region = fields.at(0);
+
     ColorOption *colorOption = new ColorOption;
 
     if(region == "left") colorOption->region = REGION_LEFT;
     if(region == "middle") colorOption->region = REGION_MIDDLE;
     if(region == "right") colorOption->region = REGION_RIGHT;
+    if(region == "logo") colorOption->region = LOGO;
+    if(region == "front-left") colorOption->region = FRL_LEFT;
+    if(region == "front-right") colorOption->region = FRL_RIGHT;
+    if(region == "touchpad") colorOption->region = TOUCHPAD;
 
-    if(color == "off") colorOption->color = COLOR_OFF;
-    if(color == "red") colorOption->color = COLOR_RED;
-    if(color == "orange") colorOption->color = COLOR_ORANGE;
-    if(color == "yellow") colorOption->color = COLOR_YELLOW;
-    if(color == "green") colorOption->color = COLOR_GREEN;
-    if(color == "sky") colorOption->color = COLOR_SKY;
-    if(color == "blue") colorOption->color = COLOR_BLUE;
-    if(color == "purple") colorOption->color = COLOR_PURPLE;
-    if(color == "white") colorOption->color = COLOR_WHITE;
-
-    if(intensity == "high") colorOption->intensity = INTENSITY_HIGH;
-    if(intensity == "medium") colorOption->intensity = INTENSITY_MEDIUM;
-    if(intensity == "low") colorOption->intensity = INTENSITY_LOW;
-    if(intensity == "light") colorOption->intensity = INTENSITY_LIGHT;
-
+    bool ok=false;
+    for (uint k=0;k<3;k++){
+        colorOption->rgb[k]=fields.at(k+1).toInt(&ok);
+        if (!ok){
+            std::cerr << "invalid color selection" << std::endl;
+            qApp->quit();
+            return;
+        }
+    }
     colorSet = true;
 
     colorOptions.append(colorOption);
@@ -100,10 +154,12 @@ CommandLineParseResult parseCommandLine(QCommandLineParser &parser, KeyboardOpti
   QCommandLineOption versionOption = parser.addVersionOption();
 
   QCommandLineOption mode(QStringList() << "m" << "mode", "set color <mode>: normal, gaming, breathe, demo, wave", "mode");
-  QCommandLineOption color(QStringList() << "c" << "color", "set a <color> using the format: region,color,intensity", "color");
+  QCommandLineOption color(QStringList() << "c" << "color", "set a <color> using the format: region,red,green,blue with rgb values between 0 and 255", "color");
+  QCommandLineOption colorPreset(QStringList() << "p" << "preset", "set a color <preset> using the format: region,color,intensity (only valid for left/middle/right regions)", "preset");
 
   parser.addOption(mode);
   parser.addOption(color);
+  parser.addOption(colorPreset);
 
   if(!parser.parse(QCoreApplication::arguments())) {
     *errorMessage = parser.errorText();
@@ -120,6 +176,12 @@ CommandLineParseResult parseCommandLine(QCommandLineParser &parser, KeyboardOpti
     keyboardOptions->setMode(parser.value(mode));
   }
 
+  if(parser.isSet(colorPreset)) {
+    foreach(const QString &presetValue, parser.values(colorPreset)) {
+      keyboardOptions->setColorPreset(presetValue);
+    }
+  }
+
   if(parser.isSet(color)) {
     foreach(const QString &colorValue, parser.values(color)) {
       keyboardOptions->setColor(colorValue);
@@ -132,7 +194,7 @@ CommandLineParseResult parseCommandLine(QCommandLineParser &parser, KeyboardOpti
 int main(int argc, char *argv[]) {
   QCoreApplication app(argc, argv);
   app.setApplicationName("msi-keyboard");
-  app.setApplicationVersion("1.0");
+  app.setApplicationVersion("1.1");
 
   QCommandLineParser parser;
   parser.setApplicationDescription("Keyboard color changer for MSI steelseries keyboards");
@@ -156,7 +218,7 @@ int main(int argc, char *argv[]) {
     {
       std::cout << qPrintable(parser.helpText()) << std::endl;
 
-      QStringList regions = QStringList() << "left" << "middle" << "right";
+      QStringList regions = QStringList() << "left" << "middle" << "right"<<"logo"<<"front-left"<<"front-right"<<"touchpad";
       QStringList colors = QStringList() << "off" << "red" << "orange" << "yellow" << "green" << "sky" << "blue" << "purple" << "white";
       QStringList intensities = QStringList() << "high" << "medium" << "low" << "light";
 
@@ -164,18 +226,18 @@ int main(int argc, char *argv[]) {
 
 %1
 
-Available colors:
+Available color presets (only for left/middle/right regions):
 
 %2
 
-Available intensities:
+Available preset intensities (only for left/middle/right regions):
 
 %3
 
 Example:
 
 %4
-)").arg(regions.join('\n')).arg(colors.join('\n')).arg(intensities.join('\n')).arg(QString(argv[0]) + " -m normal -c left,red,high -c middle,purple,high -c right,sky,high");
+)").arg(regions.join('\n')).arg(colors.join('\n')).arg(intensities.join('\n')).arg(QString(argv[0]) + " -m normal -p left,red,high -p middle,purple,high -p right,sky,high -c touchpad,255,0,0");
 
       std::cout << qPrintable(colorHelp) << std::endl;
 
@@ -183,17 +245,25 @@ Example:
     }
   }
 
-  if(!keyboardOptions.modeSet || !keyboardOptions.colorSet) {
-    std::cerr << "Please set a mode as well as at least one color region to change." << std::endl;
+  if(!keyboardOptions.modeSet && !keyboardOptions.colorSet && !keyboardOptions.presetSet) {
+    std::cerr << "Please set a mode or at least one color region to change." << std::endl;
     return 1;
   }else{
     Keyboard k;
+
+    if(keyboardOptions.presetSet) {
+      for(int i = 0; i < keyboardOptions.presetOptions.count(); ++i) {
+        ColorPresetOption *presetOption = keyboardOptions.presetOptions.at(i);
+
+        k.setColorPreset(presetOption->region, presetOption->color, presetOption->intensity);
+      }
+    }
 
     if(keyboardOptions.colorSet) {
       for(int i = 0; i < keyboardOptions.colorOptions.count(); ++i) {
         ColorOption *colorOption = keyboardOptions.colorOptions.at(i);
 
-        k.setColor(colorOption->region, colorOption->color, colorOption->intensity);
+        k.setColor(colorOption->region, colorOption->rgb);
       }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -154,8 +154,8 @@ CommandLineParseResult parseCommandLine(QCommandLineParser &parser, KeyboardOpti
   QCommandLineOption versionOption = parser.addVersionOption();
 
   QCommandLineOption mode(QStringList() << "m" << "mode", "set color <mode>: normal, gaming, breathe, demo, wave", "mode");
-  QCommandLineOption color(QStringList() << "c" << "color", "set a <color> using the format: region,red,green,blue with rgb values between 0 and 255", "color");
-  QCommandLineOption colorPreset(QStringList() << "p" << "preset", "set a color <preset> using the format: region,color,intensity (only valid for left/middle/right regions)", "preset");
+  QCommandLineOption color(QStringList() << "r" << "rgb", "set an <rgb> color using the format: region,red,green,blue with rgb values between 0 and 255", "rgb");
+  QCommandLineOption colorPreset(QStringList() << "c" << "color", "set a <color> preset using the format: region,color,intensity (only valid for left/middle/right regions). When using this option, a mode must be specified with -m", "color");
 
   parser.addOption(mode);
   parser.addOption(color);
@@ -237,7 +237,7 @@ Available preset intensities (only for left/middle/right regions):
 Example:
 
 %4
-)").arg(regions.join('\n')).arg(colors.join('\n')).arg(intensities.join('\n')).arg(QString(argv[0]) + " -m normal -p left,red,high -p middle,purple,high -p right,sky,high -c touchpad,255,0,0");
+)").arg(regions.join('\n')).arg(colors.join('\n')).arg(intensities.join('\n')).arg(QString(argv[0]) + " -m normal -c left,red,high -c middle,purple,high -c right,sky,high -r touchpad,255,0,0 -r logo,255,255,255");
 
       std::cout << qPrintable(colorHelp) << std::endl;
 
@@ -245,8 +245,8 @@ Example:
     }
   }
 
-  if(!keyboardOptions.modeSet && !keyboardOptions.colorSet && !keyboardOptions.presetSet) {
-    std::cerr << "Please set a mode or at least one color region to change." << std::endl;
+  if((!keyboardOptions.modeSet || !keyboardOptions.presetSet) && !keyboardOptions.colorSet ) {
+    std::cerr << "Please set either a mode together with at least one region to change a color preset, or a color region to change rgb color." << std::endl;
     return 1;
   }else{
     Keyboard k;


### PR DESCRIPTION
The backlit keyboard regions present in a MSI GT72/GT72s (https://www.msi.com/Laptop/GT72-6QE-DOMINATOR-PRO-G.html#hero-specification or https://www.msi.com/Laptop/GT72S-6QE-DOMINATOR-PRO-G.html#hero-specification) are more than three.

The command line options are changed to reflect the usage of presets (the former -c option is changed to -p) and colors with R,G,B specs (now -c).

While the left,middle,right regions can be changed through a preset (code 66 with region, color and intensity), the touchpad, logo and front (left/right) regions can only be changed with a code 64, paired with the RGB spec of the color. This also works with the previous left,middle,right regions.

Tested on a MSI GT72 with Arch Linux